### PR TITLE
2025 rework

### DIFF
--- a/prisma/migrations/20250925153542_add_results_tables/migration.sql
+++ b/prisma/migrations/20250925153542_add_results_tables/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+CREATE TABLE "CodamCoalitionSeasonResult" (
+    "id" SERIAL NOT NULL,
+    "coalition_id" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "bloc_deadline_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CodamCoalitionSeasonResult_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CodamCoalitionUserResult" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "coalition_id" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "season_result_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CodamCoalitionUserResult_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CodamCoalitionRankingResult" (
+    "id" SERIAL NOT NULL,
+    "ranking_type" TEXT NOT NULL,
+    "season_result_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "position" INTEGER NOT NULL,
+
+    CONSTRAINT "CodamCoalitionRankingResult_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionSeasonResult" ADD CONSTRAINT "CodamCoalitionSeasonResult_coalition_id_fkey" FOREIGN KEY ("coalition_id") REFERENCES "CodamCoalition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionSeasonResult" ADD CONSTRAINT "CodamCoalitionSeasonResult_bloc_deadline_id_fkey" FOREIGN KEY ("bloc_deadline_id") REFERENCES "IntraBlocDeadline"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionUserResult" ADD CONSTRAINT "CodamCoalitionUserResult_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "CodamUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionUserResult" ADD CONSTRAINT "CodamCoalitionUserResult_coalition_id_fkey" FOREIGN KEY ("coalition_id") REFERENCES "CodamCoalition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionUserResult" ADD CONSTRAINT "CodamCoalitionUserResult_season_result_id_fkey" FOREIGN KEY ("season_result_id") REFERENCES "CodamCoalitionSeasonResult"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250925153739_add_missing_relations/migration.sql
+++ b/prisma/migrations/20250925153739_add_missing_relations/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionRankingResult" ADD CONSTRAINT "CodamCoalitionRankingResult_ranking_type_fkey" FOREIGN KEY ("ranking_type") REFERENCES "CodamCoalitionRanking"("type") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionRankingResult" ADD CONSTRAINT "CodamCoalitionRankingResult_season_result_id_fkey" FOREIGN KEY ("season_result_id") REFERENCES "CodamCoalitionSeasonResult"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251009114505_unique_results/migration.sql
+++ b/prisma/migrations/20251009114505_unique_results/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[season_result_id,ranking_type,user_id]` on the table `CodamCoalitionRankingResult` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[coalition_id,bloc_deadline_id]` on the table `CodamCoalitionSeasonResult` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[season_result_id,coalition_id,user_id]` on the table `CodamCoalitionUserResult` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "CodamCoalitionRankingResult_season_result_id_ranking_type_u_key" ON "CodamCoalitionRankingResult"("season_result_id", "ranking_type", "user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CodamCoalitionSeasonResult_coalition_id_bloc_deadline_id_key" ON "CodamCoalitionSeasonResult"("coalition_id", "bloc_deadline_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CodamCoalitionUserResult_season_result_id_coalition_id_user_key" ON "CodamCoalitionUserResult"("season_result_id", "coalition_id", "user_id");

--- a/prisma/migrations/20251009114732_rename_position_into_rank/migration.sql
+++ b/prisma/migrations/20251009114732_rename_position_into_rank/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `position` on the `CodamCoalitionRankingResult` table. All the data in the column will be lost.
+  - Added the required column `rank` to the `CodamCoalitionRankingResult` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "CodamCoalitionRankingResult" DROP COLUMN "position",
+ADD COLUMN     "rank" INTEGER NOT NULL;

--- a/prisma/migrations/20251009120922_unlink_coalition_results_and_ranking_results/migration.sql
+++ b/prisma/migrations/20251009120922_unlink_coalition_results_and_ranking_results/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `season_result_id` on the `CodamCoalitionRankingResult` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[bloc_deadline_id,ranking_type,user_id]` on the table `CodamCoalitionRankingResult` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `bloc_deadline_id` to the `CodamCoalitionRankingResult` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `coalition_id` to the `CodamCoalitionRankingResult` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "CodamCoalitionRankingResult" DROP CONSTRAINT "CodamCoalitionRankingResult_season_result_id_fkey";
+
+-- DropIndex
+DROP INDEX "CodamCoalitionRankingResult_season_result_id_ranking_type_u_key";
+
+-- AlterTable
+ALTER TABLE "CodamCoalitionRankingResult" DROP COLUMN "season_result_id",
+ADD COLUMN     "bloc_deadline_id" INTEGER NOT NULL,
+ADD COLUMN     "coalition_id" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CodamCoalitionRankingResult_bloc_deadline_id_ranking_type_u_key" ON "CodamCoalitionRankingResult"("bloc_deadline_id", "ranking_type", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionRankingResult" ADD CONSTRAINT "CodamCoalitionRankingResult_bloc_deadline_id_fkey" FOREIGN KEY ("bloc_deadline_id") REFERENCES "IntraBlocDeadline"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251009121117_unlink_coalition_and_ranking_result/migration.sql
+++ b/prisma/migrations/20251009121117_unlink_coalition_and_ranking_result/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `coalition_id` on the `CodamCoalitionRankingResult` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "CodamCoalitionRankingResult" DROP COLUMN "coalition_id";

--- a/prisma/migrations/20251009121235_add_user_ranking_relation/migration.sql
+++ b/prisma/migrations/20251009121235_add_user_ranking_relation/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionRankingResult" ADD CONSTRAINT "CodamCoalitionRankingResult_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "CodamUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251009150224_relink_ranking_results_to_coalitions/migration.sql
+++ b/prisma/migrations/20251009150224_relink_ranking_results_to_coalitions/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "CodamCoalitionRankingResult" ADD COLUMN     "coalition_id" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "CodamCoalitionRankingResult" ADD CONSTRAINT "CodamCoalitionRankingResult_coalition_id_fkey" FOREIGN KEY ("coalition_id") REFERENCES "CodamCoalition"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20251009155830_add_rankings_to_user_results/migration.sql
+++ b/prisma/migrations/20251009155830_add_rankings_to_user_results/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `coalition_rank` to the `CodamCoalitionUserResult` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "CodamCoalitionUserResult" ADD COLUMN     "coalition_rank" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,7 @@ model CodamCoalitionUserResult {
 	user_id          Int
 	coalition_id     Int
 	score            Int
+	coalition_rank   Int      // No. in the coalition (1 = first, 2 = second, etc.)
 	season_result_id Int
 
 	created_at       DateTime @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,7 +91,7 @@ model CodamCoalitionScore {
 model CodamCoalitionSeasonResult {
 	id               Int      @id @default(autoincrement())
 	coalition_id     Int
-	score            Int
+	score            Int      // NOT the same as the sum of all scores, but the score after applying the normal distribution
 	bloc_deadline_id Int
 
 	created_at       DateTime @default(now())
@@ -104,6 +104,9 @@ model CodamCoalitionSeasonResult {
 
 	// Link to Intra
 	bloc_deadline    IntraBlocDeadline @relation(fields: [bloc_deadline_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+	// Make coalition_id + bloc_deadline_id unique together
+	@@unique([coalition_id, bloc_deadline_id])
 }
 
 model CodamCoalitionUserResult {
@@ -120,6 +123,9 @@ model CodamCoalitionUserResult {
 	user             CodamUser        @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 	coalition        CodamCoalition   @relation(fields: [coalition_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 	season_result    CodamCoalitionSeasonResult @relation(fields: [season_result_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+	// Make season_result_id + coalition_id + user_id unique together
+	@@unique([season_result_id, coalition_id, user_id])
 }
 
 model CodamCoalitionRankingResult {
@@ -128,11 +134,14 @@ model CodamCoalitionRankingResult {
 	season_result_id Int
 	user_id          Int
 	score            Int
-	position         Int
+	rank             Int
 
 	// Relations
 	ranking          CodamCoalitionRanking @relation(fields: [ranking_type], references: [type], onDelete: Cascade, onUpdate: Cascade)
 	season_result    CodamCoalitionSeasonResult @relation(fields: [season_result_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+	// Make season_result_id + ranking_type + user_id unique together
+	@@unique([season_result_id, ranking_type, user_id])
 }
 
 // Sorting hat quiz settings

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model CodamCoalition {
 	coalition_test_answers CodamCoalitionTestAnswer[]
 	season_results   CodamCoalitionSeasonResult[]
 	user_results     CodamCoalitionUserResult[]
+	ranking_results  CodamCoalitionRankingResult[]
 
 	// Link to Intra
 	intra_coalition  IntraCoalition   @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -133,11 +134,13 @@ model CodamCoalitionRankingResult {
 	ranking_type     String
 	bloc_deadline_id Int   // The bloc deadline (season) this ranking was for
 	user_id          Int
+	coalition_id     Int?
 	score            Int
 	rank             Int   // No. in the ranking (1 = first, 2 = second, etc.)
 
 	// Relations
 	user             CodamUser        @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+	coalition        CodamCoalition?  @relation(fields: [coalition_id], references: [id], onDelete: SetNull, onUpdate: Cascade)
 	ranking          CodamCoalitionRanking @relation(fields: [ranking_type], references: [type], onDelete: Cascade, onUpdate: Cascade)
 
 	// Link to Intra

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model CodamUser {
 	// Relations
 	coalition_scores CodamCoalitionScore[]
 	user_results     CodamCoalitionUserResult[]
+	user_rankings    CodamCoalitionRankingResult[]
 
 	// Link to Intra
 	intra_user       IntraUser   @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -100,7 +101,6 @@ model CodamCoalitionSeasonResult {
 	// Relations
 	coalition        CodamCoalition    @relation(fields: [coalition_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 	scores           CodamCoalitionUserResult[]
-	rankings         CodamCoalitionRankingResult[]
 
 	// Link to Intra
 	bloc_deadline    IntraBlocDeadline @relation(fields: [bloc_deadline_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -131,17 +131,20 @@ model CodamCoalitionUserResult {
 model CodamCoalitionRankingResult {
 	id               Int      @id @default(autoincrement())
 	ranking_type     String
-	season_result_id Int
+	bloc_deadline_id Int   // The bloc deadline (season) this ranking was for
 	user_id          Int
 	score            Int
-	rank             Int
+	rank             Int   // No. in the ranking (1 = first, 2 = second, etc.)
 
 	// Relations
+	user             CodamUser        @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 	ranking          CodamCoalitionRanking @relation(fields: [ranking_type], references: [type], onDelete: Cascade, onUpdate: Cascade)
-	season_result    CodamCoalitionSeasonResult @relation(fields: [season_result_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
-	// Make season_result_id + ranking_type + user_id unique together
-	@@unique([season_result_id, ranking_type, user_id])
+	// Link to Intra
+	bloc_deadline    IntraBlocDeadline @relation(fields: [bloc_deadline_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+	// Make bloc_deadline_id + ranking_type + user_id unique together
+	@@unique([bloc_deadline_id, ranking_type, user_id])
 }
 
 // Sorting hat quiz settings
@@ -237,6 +240,7 @@ model IntraBlocDeadline {
 
 	// Codam
 	codam_season_result CodamCoalitionSeasonResult[]
+	codam_ranking_results CodamCoalitionRankingResult[]
 }
 
 // Intra Coalition

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model CodamUser {
 
 	// Relations
 	coalition_scores CodamCoalitionScore[]
+	user_results     CodamCoalitionUserResult[]
 
 	// Link to Intra
 	intra_user       IntraUser   @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -29,6 +30,8 @@ model CodamCoalition {
 	// Relations
 	coalition_scores CodamCoalitionScore[]
 	coalition_test_answers CodamCoalitionTestAnswer[]
+	season_results   CodamCoalitionSeasonResult[]
+	user_results     CodamCoalitionUserResult[]
 
 	// Link to Intra
 	intra_coalition  IntraCoalition   @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -45,6 +48,7 @@ model CodamCoalitionRanking {
 	disabled         Boolean  @default(false) // If disabled, this ranking will not be calculated at the end of a tournament
 
 	fixed_types      CodamCoalitionFixedType[] // The #1 is calculated by the sum of all fixed types of the same ranking type
+	results          CodamCoalitionRankingResult[]
 }
 
 // Fixed type of score for the coalition system
@@ -82,6 +86,53 @@ model CodamCoalitionScore {
 	// Link to Intra
 	intra_score_id   Int?     @unique
 	// intra_score      IntraScore?   @relation(fields: [intra_score_id], references: [id])
+}
+
+model CodamCoalitionSeasonResult {
+	id               Int      @id @default(autoincrement())
+	coalition_id     Int
+	score            Int
+	bloc_deadline_id Int
+
+	created_at       DateTime @default(now())
+	updated_at       DateTime @default(now()) @updatedAt
+
+	// Relations
+	coalition        CodamCoalition    @relation(fields: [coalition_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+	scores           CodamCoalitionUserResult[]
+	rankings         CodamCoalitionRankingResult[]
+
+	// Link to Intra
+	bloc_deadline    IntraBlocDeadline @relation(fields: [bloc_deadline_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+}
+
+model CodamCoalitionUserResult {
+	id               Int      @id @default(autoincrement())
+	user_id          Int
+	coalition_id     Int
+	score            Int
+	season_result_id Int
+
+	created_at       DateTime @default(now())
+	updated_at       DateTime @default(now()) @updatedAt
+
+	// Relations
+	user             CodamUser        @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+	coalition        CodamCoalition   @relation(fields: [coalition_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+	season_result    CodamCoalitionSeasonResult @relation(fields: [season_result_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+}
+
+model CodamCoalitionRankingResult {
+	id               Int      @id @default(autoincrement())
+	ranking_type     String
+	season_result_id Int
+	user_id          Int
+	score            Int
+	position         Int
+
+	// Relations
+	ranking          CodamCoalitionRanking @relation(fields: [ranking_type], references: [type], onDelete: Cascade, onUpdate: Cascade)
+	season_result    CodamCoalitionSeasonResult @relation(fields: [season_result_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 
 // Sorting hat quiz settings
@@ -174,6 +225,9 @@ model IntraBlocDeadline {
 	// Relations
 	bloc             IntraBloc         @relation(fields: [bloc_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 	coalition        IntraCoalition?   @relation(fields: [coalition_id], references: [id], onDelete: SetNull, onUpdate: Cascade)
+
+	// Codam
+	codam_season_result CodamCoalitionSeasonResult[]
 }
 
 // Intra Coalition

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,7 @@ model CodamCoalitionRanking {
 
 // Fixed type of score for the coalition system
 model CodamCoalitionFixedType {
-	type             String   @id // should not contain spaces. e.g. "project", "eval", "point_donated", "logtime", "exam", "basic_event", "intermediate_event", "advanced_event"
+	type             String   @id // should not contain spaces. e.g. "project", "eval", "point_donated", "logtime", "idle_logout", "exam", "basic_event", "intermediate_event", "advanced_event"
 	description      String
 	point_amount     Int
 	ranking_type     String?  // The ranking type that this fixed type of score contributes to (leave empty to disable ranking, does not need to be unique)

--- a/src/dev/create_rankings.ts
+++ b/src/dev/create_rankings.ts
@@ -29,7 +29,7 @@ const createRanking = async function(name: string, description: string, topTitle
 const createRankings = async function(): Promise<void> {
 	await createRanking('Guiding Stars', 'Based on points gained through evaluations', 'Guiding Star', 100000, ['evaluation']);
 	await createRanking('Top Performers', 'Based on points gained through projects', 'Top Performer', 100000, ['project', 'exam']);
-	await createRanking('Top Endeavors', 'Based on points gained through logtime', 'Top Endeavor', 100000, ['logtime']);
+	await createRanking('Top Endeavors', 'Based on points gained through logtime', 'Top Endeavor', 100000, ['logtime', 'idle_logout']);
 	await createRanking('Philanthropists', 'Based on points gained through donating evaluation points to the pool', 'Philanthropist', 100000, ['point_donated']);
 	await createRanking('Community Leaders', 'Based on points gained through organizing events', 'Community Leader', 100000, ['event_basic', 'event_intermediate', 'event_advanced']);
 };

--- a/src/dev/delete_all_results.ts
+++ b/src/dev/delete_all_results.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+import readline from 'readline';
+
+const main = async function(): Promise<void> {
+	console.log('This will delete all previously calculated results from the database. Are you sure you want to continue? (yes/no)');
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	if (await new Promise((resolve) => {
+		rl.question('', (answer) => {
+			rl.close();
+			resolve(answer);
+		});
+	}) !== 'yes') {
+		console.log('Aborting...');
+		process.exit(0);
+	}
+	await prisma.codamCoalitionRankingResult.deleteMany({});
+	await prisma.codamCoalitionUserResult.deleteMany({});
+	await prisma.codamCoalitionSeasonResult.deleteMany({});
+};
+
+main().then(() => {
+	console.log('All results have been deleted from the database');
+	process.exit(0);
+});

--- a/src/handlers/filters.ts
+++ b/src/handlers/filters.ts
@@ -95,4 +95,13 @@ export const setupNunjucksFilters = function(app: Express): void {
 	nunjucksEnv.addFilter('bool', (value: boolean) => {
 		return value ? 'true' : 'false';
 	});
+
+	// Add filter to name a season
+	nunjucksEnv.addFilter('seasonName', (season: any) => {
+		if (!season || !season.begin_at || !season.end_at) {
+			return 'Unknown season';
+		}
+		// return `${season.begin_at.getFullYear()}-${season.begin_at.getMonth() + 1} > ${season.end_at.getFullYear()}-${season.end_at.getMonth() + 1}`;
+		return `${season.end_at.toLocaleString('en-US', { month: 'short' })} ${season.end_at.getFullYear()}`;
+	});
 };

--- a/src/handlers/filters.ts
+++ b/src/handlers/filters.ts
@@ -104,4 +104,12 @@ export const setupNunjucksFilters = function(app: Express): void {
 		// return `${season.begin_at.getFullYear()}-${season.begin_at.getMonth() + 1} > ${season.end_at.getFullYear()}-${season.end_at.getMonth() + 1}`;
 		return `${season.end_at.toLocaleString('en-US', { month: 'short' })} ${season.end_at.getFullYear()}`;
 	});
+
+	// Add filter to remove the first item from a list
+	nunjucksEnv.addFilter('skipFirst', (arr: any[] | undefined | null) => {
+		if (!arr || typeof arr !== 'object' || !Array.isArray(arr)) {
+			return [];
+		}
+		return arr.slice(1);
+	});
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { setupHomeRoutes } from './routes/home';
 import { setupWebhookRoutes } from './routes/hooks';
 import { setupProfileRoutes } from './routes/profile';
 import { setupChartRoutes } from './routes/charts';
+import { setupResultsRoutes } from './routes/results';
 
 export let api: Fast42 | null = null;
 
@@ -75,6 +76,7 @@ const main = async () => {
 	setupLoginRoutes(app);
 	setupHomeRoutes(app, prisma);
 	setupProfileRoutes(app, prisma);
+	setupResultsRoutes(app, prisma);
 	setupChartRoutes(app, prisma);
 	setupQuizRoutes(app, prisma);
 	setupAdminRoutes(app, prisma);

--- a/src/routes/charts.ts
+++ b/src/routes/charts.ts
@@ -139,6 +139,7 @@ export const setupChartRoutes = function(app: Express, prisma: PrismaClient): vo
 							// @ts-ignore
 							tension: 0.25,
 						},
+						/*
 						{
 							label: 'Average points',
 							data: Object.values(dataPoints).map((score) => score.avgPoints),
@@ -166,6 +167,7 @@ export const setupChartRoutes = function(app: Express, prisma: PrismaClient): vo
 							// @ts-ignore
 							tension: 0.25,
 						},
+						*/
 					],
 				},
 				options: {

--- a/src/routes/hooks.ts
+++ b/src/routes/hooks.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { Express, Response } from 'express';
 import { handleLocationCloseWebhook, Location } from './hooks/locations';
+import { handleIdleLogoutWebhook, IdleLogout } from './hooks/idlelogout';
 import { handleProjectsUserUpdateWebhook, ProjectUser } from './hooks/projects_users';
 import { handleScaleTeamUpdateWebhook, ScaleTeam } from './hooks/scale_teams';
 import { handlePointGivenWebhook, PointGiven } from './hooks/pools';
@@ -80,6 +81,9 @@ export const handleWebhook = async function(prisma: PrismaClient, modelType: str
 		case "location": // location close
 			const location: Location = body as Location;
 			return await handleLocationCloseWebhook(prisma, location, res, deliveryId);
+		case "idle_logout": // idle logout
+			const autoLogout: IdleLogout = body as IdleLogout;
+			return await handleIdleLogoutWebhook(prisma, autoLogout, res, deliveryId);
 		case "projects_user": // project or exam validation
 			const projectUser: ProjectUser = body as ProjectUser;
 			return await handleProjectsUserUpdateWebhook(prisma, projectUser, res, deliveryId);

--- a/src/routes/hooks/idlelogout.ts
+++ b/src/routes/hooks/idlelogout.ts
@@ -1,0 +1,57 @@
+import { Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { WebhookHandledStatus, respondWebHookHandledStatus } from '../hooks';
+import { handleFixedPointScore } from '../../handlers/points';
+
+/**
+ * Idle Logouts? What are those, you might ask.
+ * These are automatic logouts that happen when a user leaves a computer idling too long.
+ * This is not implemented in Intra, there is no Intra webhook for this functionality. It needs to be manually implemented in the cluster computers,
+ * which should call this webhook when an automatic logout after idling happens.
+ *
+ * Why would we want to do this?
+ * This is to discourage users from leaving computers idling for too long, as it wastes energy and prevents other users from using the computer.
+ * Plus, the users would gain points from leaving a computer idling and remaining logged in, as it counts towards their logtime, which is not the intended behavior.
+ * This implementation thus punishes users for doing this.
+ */
+
+export interface IdleLogout {
+	host: string;
+	user: {
+		id: number;
+		login: string;
+	},
+	logged_out_at: string;
+}
+
+export const handleIdleLogoutWebhook = async function(prisma: PrismaClient, autoLogout: IdleLogout, res: Response | null = null, webhookDeliveryId: string | null = null): Promise<Response | null> {
+	try {
+		// Get fixed point type
+		const fixedPointType = await prisma.codamCoalitionFixedType.findFirst({
+			where: {
+				type: 'idle_logout',
+			},
+		});
+		if (!fixedPointType || fixedPointType.point_amount === 0) {
+			console.warn("No fixed point type found for idle_logout or point amount is set to 0, skipping...");
+			return (res ? respondWebHookHandledStatus(prisma, webhookDeliveryId, res, WebhookHandledStatus.Skipped) : null);
+		}
+
+		// Calculate the score
+		const loggedOutAt = new Date(autoLogout.logged_out_at);
+		const points = fixedPointType.point_amount;
+
+		// Create a score
+		const score = await handleFixedPointScore(prisma, fixedPointType, null, autoLogout.user.id, points,
+			`Was automatically logged out of ${autoLogout.host} after leaving it idling too long`, loggedOutAt);
+		if (!score) {
+			console.warn("Refused or failed to create score, skipping...");
+			return (res ? respondWebHookHandledStatus(prisma, webhookDeliveryId, res, WebhookHandledStatus.Skipped) : null);
+		}
+		return (res ? respondWebHookHandledStatus(prisma, webhookDeliveryId, res, WebhookHandledStatus.Ok) : null);
+	}
+	catch (error) {
+		console.error("Failed to handle idle_logout close webhook", error);
+		return (res ? respondWebHookHandledStatus(prisma, webhookDeliveryId, res, WebhookHandledStatus.Error) : null);
+	}
+};

--- a/src/routes/hooks/projects_users.ts
+++ b/src/routes/hooks/projects_users.ts
@@ -1,6 +1,5 @@
 import { Response } from 'express';
 import { CodamCoalitionFixedType, PrismaClient } from '@prisma/client';
-import Fast42 from '@codam/fast42';
 import { WebhookHandledStatus, respondWebHookHandledStatus } from '../hooks';
 import { handleFixedPointScore } from '../../handlers/points';
 

--- a/src/routes/hooks/scale_teams.ts
+++ b/src/routes/hooks/scale_teams.ts
@@ -1,6 +1,5 @@
 import { Response } from 'express';
 import { PrismaClient } from '@prisma/client';
-import Fast42 from '@codam/fast42';
 import { WebhookHandledStatus, respondWebHookHandledStatus } from '../hooks';
 import { handleFixedPointScore } from '../../handlers/points';
 

--- a/src/routes/results.ts
+++ b/src/routes/results.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+import { Express } from 'express';
+import { getUserScores, getUserRankingAcrossAllRankings, getUserTournamentRanking, getEndedSeasons, getSeasonResults } from '../utils';
+
+export const setupResultsRoutes = function(app: Express, prisma: PrismaClient): void {
+	app.get('/results', async (req, res) => {
+		// Redirect to the latest (ended) bloc deadline results page
+		const endedSeasons = await getEndedSeasons(prisma);
+		if (endedSeasons.length > 0) {
+			return res.redirect(`/results/${endedSeasons[0].id}`);
+		}
+		return res.status(404).send('No previous seasons have ended yet. Come back later!');
+	});
+
+	app.get('/results/:bloc_deadline_id', async (req, res) => {
+		const endedSeasons = await getEndedSeasons(prisma);
+		const season = endedSeasons.find(season => season.id === parseInt(req.params.bloc_deadline_id, 10));
+		if (!season) {
+			return res.status(404).send('Season not found or has not ended yet.');
+		}
+
+		const { seasonResults, rankings } = await getSeasonResults(prisma, season.id, 10);
+
+		return res.render('results.njk', {
+			endedSeasons,
+			season,
+			seasonResults,
+			rankings,
+		});
+	});
+};

--- a/src/sync/base.ts
+++ b/src/sync/base.ts
@@ -12,6 +12,7 @@ import { syncProjects } from "./projects";
 import { syncCursusUsers } from './cursus_users';
 import { syncScores } from './scores';
 import { getBlocAtDate } from '../utils';
+import { calculateResults } from './results';
 
 export const prisma = new PrismaClient();
 
@@ -228,6 +229,7 @@ export const syncWithIntra = async function(api: Fast42): Promise<void> {
 		await syncCursusUsers(api, lastSync, now);
 		await syncBlocs(api, now); // also syncs coalitions
 		await syncCoalitionUsers(api, lastSync, now);
+		await calculateResults();
 		await cleanupDB(api);
 
 		const currentBloc = await getBlocAtDate(prisma, new Date()); // Check if a season is currently ongoing (only then we can sync)

--- a/src/sync/blocs.ts
+++ b/src/sync/blocs.ts
@@ -1,6 +1,6 @@
 import Fast42 from '@codam/fast42';
 import { prisma, syncData } from './base';
-import { syncCoalition } from './coalitions';
+import { linkCoalitionToBloc, syncCoalition } from './coalitions';
 import { CAMPUS_ID, CURSUS_ID } from '../env';
 import { IntraBlocDeadline, Prisma } from '@prisma/client';
 import { DefaultArgs } from '@prisma/client/runtime/library';
@@ -30,6 +30,7 @@ export const syncBloc = async function(bloc: any): Promise<void> {
 		// Sync the bloc's coalitions
 		for (const coalition of bloc.coalitions) {
 			await syncCoalition(coalition);
+			await linkCoalitionToBloc(coalition.id, bloc.id);
 		}
 	}
 	catch (err) {

--- a/src/sync/coalitions.ts
+++ b/src/sync/coalitions.ts
@@ -49,3 +49,51 @@ export const syncCoalition = async function(coalition: any): Promise<void> {
 		console.error(`Error syncing coalition ${coalition.name}: ${err}`);
 	}
 };
+
+export async function linkCoalitionToBloc(coalitionId: number, blocId: number): Promise<void> {
+	try {
+		const coalition = await prisma.intraCoalition.findUnique({
+			where: {
+				id: coalitionId,
+			},
+			include: {
+				blocs: true,
+			},
+		});
+		if (!coalition) {
+			throw new Error(`Coalition with id ${coalitionId} not found`);
+		}
+
+		const bloc = await prisma.intraBloc.findUnique({
+			where: {
+				id: blocId,
+			},
+		});
+		if (!bloc) {
+			throw new Error(`Bloc with id ${blocId} not found`);
+		}
+
+		// Check if the coalition is already linked to the bloc
+		const isLinked = coalition.blocs.some(b => b.id === blocId);
+		if (isLinked) {
+			// Already linked
+			return;
+		}
+
+		// Link the coalition to the bloc
+		console.log(`Linking coalition ${coalitionId} to bloc ${blocId}`);
+		await prisma.intraCoalition.update({
+			where: {
+				id: coalitionId,
+			},
+			data: {
+				blocs: {
+					connect: { id: blocId },
+				}
+			},
+		});
+	}
+	catch (error) {
+		console.error(`Error linking coalition ${coalitionId} to bloc ${blocId}: ${error}`);
+	}
+};

--- a/src/sync/fixed_point_types.ts
+++ b/src/sync/fixed_point_types.ts
@@ -55,6 +55,11 @@ export const initCodamCoalitionFixedTypes = async function(): Promise<void> {
 			points: 10, // recommended
 		},
 		{
+			type: "idle_logout",
+			desc: "Each automatic logout after leaving a computer idling too long will deduct this amount of points (should be negative and needs to be manually implemented in the cluster computers).",
+			points: -10, // recommended
+		},
+		{
 			type: "exam",
 			desc: "Each exam passed will grant the student with this amount of points",
 			points: 1000, // recommended

--- a/src/sync/results.ts
+++ b/src/sync/results.ts
@@ -38,6 +38,21 @@ export const calculateResults = async function(): Promise<void> {
 		for (const coalition of season.bloc.coalitions) {
 			console.log(` - Calculating results for coalition ${coalition.name}...`);
 
+			// Check if there are any scores at all for this coalition in this season
+			const scoresCount = await prisma.codamCoalitionScore.count({
+				where: {
+					coalition_id: coalition.id,
+					created_at: {
+						gte: season.begin_at,
+						lte: season.end_at,
+					},
+				},
+			});
+			if (scoresCount === 0) {
+				console.log(`   - No scores found for coalition ${coalition.name} in season ${seasonName}, skipping...`);
+				continue;
+			}
+
 			// Entire coalition score
 			const score = await getScoresNormalDistribution(prisma, coalition.id, season.end_at);
 			console.log(`   - Final score for coalition ${coalition.name} in season ${seasonName}: ${score.mean}`);
@@ -52,13 +67,20 @@ export const calculateResults = async function(): Promise<void> {
 			// Individual user scores
 			const usersScores = await getUsersScores(prisma, coalition.id, season.end_at, RANKING_MAX);
 			console.log(`   - Calculating individual results for ${usersScores.length} users in coalition ${coalition.name}...`);
+			let rank = 0;
+			let lastScore = Infinity;
 			for (const userScore of usersScores) {
 				console.log(`     - User ${userScore.user_id} scored ${userScore._sum.amount} points in coalition ${coalition.name}`);
+				if ((userScore._sum.amount || 0) < lastScore) {
+					rank++;
+					lastScore = userScore._sum.amount || 0;
+				}
 				const userResult = await prisma.codamCoalitionUserResult.create({
 					data: {
 						user_id: userScore.user_id,
 						coalition_id: coalition.id,
 						score: userScore._sum.amount || 0,
+						coalition_rank: rank,
 						season_result_id: result.id,
 					}
 				});

--- a/src/sync/results.ts
+++ b/src/sync/results.ts
@@ -1,7 +1,8 @@
-import { getRanking, getScoresNormalDistribution, getUserScores, RANKING_MAX } from '../utils';
+import { getRanking, getScoresNormalDistribution, getUsersScores, RANKING_MAX } from '../utils';
 import { prisma } from './base';
 
 export const calculateResults = async function(): Promise<void> {
+	console.log('Checking if any seasons have finished but have no results stored yet...');
 	// Check if a season has ended but no results have been calculated yet
 	const seasonsToCalculate = await prisma.intraBlocDeadline.findMany({
 		where: {
@@ -49,28 +50,15 @@ export const calculateResults = async function(): Promise<void> {
 			});
 
 			// Individual user scores
-			const coalitionUsers = await prisma.intraCoalitionUser.findMany({
-				where: {
-					coalition_id: coalition.id,
-				},
-				select: {
-					user_id: true,
-					user: {
-						select: {
-							login: true,
-						},
-					},
-				},
-			});
-			console.log(`   - Calculating individual results for ${coalitionUsers.length} users in coalition ${coalition.name}...`);
-			for (const coalitionUser of coalitionUsers) {
-				const { userScores, totalScore } = await getUserScores(prisma, coalitionUser.user_id, season.end_at);
-				console.log(`     - User ${coalitionUser.user.login} scored ${totalScore} points in coalition ${coalition.name}`);
+			const usersScores = await getUsersScores(prisma, coalition.id, season.end_at, RANKING_MAX);
+			console.log(`   - Calculating individual results for ${usersScores.length} users in coalition ${coalition.name}...`);
+			for (const userScore of usersScores) {
+				console.log(`     - User ${userScore.user_id} scored ${userScore._sum.amount} points in coalition ${coalition.name}`);
 				const userResult = await prisma.codamCoalitionUserResult.create({
 					data: {
-						user_id: coalitionUser.user_id,
+						user_id: userScore.user_id,
 						coalition_id: coalition.id,
-						score: totalScore,
+						score: userScore._sum.amount || 0,
 						season_result_id: result.id,
 					}
 				});
@@ -81,14 +69,16 @@ export const calculateResults = async function(): Promise<void> {
 		const rankings = await prisma.codamCoalitionRanking.findMany({});
 		console.log(` - Calculating tournament rankings for season ${seasonName}...`);
 		for (const ranking of rankings) {
+			console.log(`   - Calculating ranking ${ranking.type}...`);
 			const rankings = await getRanking(prisma, ranking.type, season.end_at, RANKING_MAX);
 			for (const userRanking of rankings) {
-				console.log(`   - User ${userRanking.user.login} ranked #${userRanking.rank} with ${userRanking.score} points in ranking ${ranking.type}`);
+				console.log(`     - User ${userRanking.user.login} ranked #${userRanking.rank} with ${userRanking.score} points in ranking ${ranking.type}`);
 				const dbRanking = await prisma.codamCoalitionRankingResult.create({
 					data: {
 						ranking_type: ranking.type,
 						bloc_deadline_id: season.id,
 						user_id: userRanking.user.id,
+						coalition_id: (userRanking.coalition ? userRanking.coalition.id : null),
 						rank: userRanking.rank,
 						score: userRanking.score,
 					}

--- a/src/sync/results.ts
+++ b/src/sync/results.ts
@@ -1,0 +1,99 @@
+import { getRanking, getScoresNormalDistribution, getUserScores, RANKING_MAX } from '../utils';
+import { prisma } from './base';
+
+export const calculateResults = async function(): Promise<void> {
+	// Check if a season has ended but no results have been calculated yet
+	const seasonsToCalculate = await prisma.intraBlocDeadline.findMany({
+		where: {
+			end_at: {
+				lt: new Date(), // Where a season has ended
+			},
+			coalition_id: {
+				not: null, // Where a winner is defined on Intra
+			},
+			codam_season_result: {
+				none: {}, // Where no results have been calculated yet on the Codam Coalition System
+			},
+		},
+		include: {
+			bloc: {
+				include: {
+					coalitions: true, // All coalitions in the bloc
+				},
+			},
+			coalition: true, // Winning coalition
+		},
+	});
+
+	if (seasonsToCalculate.length === 0) {
+		console.log('No seasons to calculate results for.');
+		return;
+	}
+
+	// Calculate results for each season that needs it
+	for (const season of seasonsToCalculate) {
+		console.log(`Calculating results for season ${season.coalition?.name} (ended at ${season.end_at.toISOString()})...`);
+		for (const coalition of season.bloc.coalitions) {
+			console.log(` - Calculating results for coalition ${coalition.name}...`);
+
+			// Entire coalition score
+			const score = await getScoresNormalDistribution(prisma, coalition.id, season.end_at);
+			console.log(`   - Total score for coalition ${coalition.name}: ${score}`);
+			const result = await prisma.codamCoalitionSeasonResult.create({
+				data: {
+					coalition_id: coalition.id,
+					score: score.mean,
+					bloc_deadline_id: season.id,
+				},
+			});
+
+			// Individual user scores
+			const users = await prisma.intraCoalitionUser.findMany({
+				where: {
+					coalition_id: coalition.id,
+				},
+				select: {
+					user_id: true,
+					user: {
+						select: {
+							login: true,
+						},
+					},
+				},
+			});
+			for (const user of users) {
+				const { userScores, totalScore } = await getUserScores(prisma, user.user_id, season.end_at);
+				if (totalScore === 0) {
+					continue;
+				}
+				console.log(`   - User ${user.user.login} scored ${totalScore} points in coalition ${coalition.name}`);
+				const userResult = await prisma.codamCoalitionUserResult.create({
+					data: {
+						user_id: user.user_id,
+						coalition_id: coalition.id,
+						score: totalScore,
+						season_result_id: result.id,
+					}
+				});
+			}
+
+			// Tournament rankings
+			const rankings = await prisma.codamCoalitionRanking.findMany({});
+			for (const ranking of rankings) {
+				const rankings = await getRanking(prisma, ranking.type, season.end_at, RANKING_MAX);
+				for (const userRanking of rankings) {
+					console.log(`   - User ${userRanking.user.login} ranked #${userRanking.rank} with ${userRanking.score} points in ranking ${ranking.type}`);
+					const dbRanking = await prisma.codamCoalitionRankingResult.create({
+						data: {
+							ranking_type: ranking.type,
+							season_result_id: result.id,
+							user_id: userRanking.user.id,
+							rank: userRanking.rank,
+							score: userRanking.score,
+						}
+					});
+				}
+			}
+		}
+	}
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -504,12 +504,16 @@ export const getRanking = async function(prisma: PrismaClient, rankingType: stri
 		throw new Error(`Ranking type ${rankingType} not found`);
 	}
 
-	// TODO: take into account the TOURNAMENT (not SEASONS!)
+	const bloc = await getBlocAtDate(prisma, atDateTime);
+	if (!bloc) { // No season currently ongoing
+		return [];
+	}
 	const scores = await prisma.codamCoalitionScore.groupBy({
 		by: ['user_id'],
 		where: {
 			created_at: {
 				lte: atDateTime,
+				gte: bloc.begin_at,
 			},
 			fixed_type_id: {
 				in: ranking.fixed_types.map(t => t.type),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -635,7 +635,7 @@ export const getUserRankingAcrossAllRankings = async function(prisma: PrismaClie
 	return userRankings.sort((a, b) => a.rank - b.rank);
 };
 
-export const getEndedSeasons = async function(prisma: PrismaClient): Promise<IntraBlocDeadline[]> {
+export const getEndedSeasons = async function(prisma: PrismaClient): Promise<(IntraBlocDeadline & { coalition: IntraCoalition | null })[]> {
 	const now = new Date();
 	const seasons = await prisma.intraBlocDeadline.findMany({
 		where: {
@@ -645,6 +645,9 @@ export const getEndedSeasons = async function(prisma: PrismaClient): Promise<Int
 		},
 		orderBy: {
 			end_at: 'desc',
+		},
+		include: {
+			coalition: true, // Winning coalition
 		},
 	});
 	return seasons;

--- a/static/css/bootstrap-overruler.css
+++ b/static/css/bootstrap-overruler.css
@@ -121,16 +121,22 @@
 	border-radius: initial !important;
 }
 
-.list-group-numbered.custom-numbers {
+.list-group-numbered.custom-numbers,
+.list-group-numbered.custom-number {
 	counter-reset: item;
 	list-style-type: none;
 }
-.list-group-numbered.custom-numbers li {
+.list-group-numbered.custom-numbers li,
+.list-group-numbered.custom-number li {
 	display: block;
 }
 .list-group-numbered.custom-numbers li:before {
 	content: counter(item) ". ";
 	counter-increment: item;
+	text-align: center;
+}
+.list-group-numbered.custom-number li:before {
+	content: attr(data-number) ". ";
 	text-align: center;
 }
 

--- a/templates/base.njk
+++ b/templates/base.njk
@@ -40,6 +40,9 @@
 					<li class="nav-item">
 						<a class="nav-link" href="/profile/me">Profile</a>
 					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="/results">Results</a>
+					</li>
 					{% if user.isStaff %}
 					<li class="nav-item dropdown">
 						<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/templates/base.njk
+++ b/templates/base.njk
@@ -33,7 +33,7 @@
 				<span class="navbar-toggler-icon"></span>
 			</button>
 			<div class="collapse navbar-collapse" id="navbarNavDropdown">
-				<ul class="navbar-nav">
+				<ul class="navbar-nav flex-grow-1">
 					<li class="nav-item">
 						<a class="nav-link" aria-current="page" href="/">Home</a>
 					</li>
@@ -65,6 +65,28 @@
 					</li>
 					{% endif %}
 				</ul>
+				<form class="d-flex" role="search" method="GET" action="/profile/" id="user-search-form">
+					<div class="input-group">
+						<span class="input-group-text" id="user-search">@</span>
+						<input class="form-control me-2" type="search" placeholder="Search user by login" aria-label="Username" id="user-search-input" aria-describedby="user-search" required />
+					</div>
+				</form>
+				<script>
+				function userSearchSetup() {
+					const form = document.getElementById('user-search-form');
+					const input = document.getElementById('user-search-input');
+					if (form && input) {
+						form.addEventListener('submit', (event) => {
+							if (!input.value) {
+								event.preventDefault();
+								return false;
+							}
+							form.action = '/profile/' + encodeURIComponent(input.value);
+						});
+					}
+				}
+				document.addEventListener('DOMContentLoaded', userSearchSetup);
+				</script>
 			</div>
 		</div>
 	</nav>

--- a/templates/results.njk
+++ b/templates/results.njk
@@ -17,18 +17,51 @@
 
 <!-- main page content -->
 <div class="container-lg mw-900">
-	<!-- leaderboard result -->
-	<div class="card w-100 mb-4" id="leaderboards" style="overflow: hidden;">
-		<div class="card-header pe-2 d-flex align-items-center" style="background-color: #6c757d;">
-			<div class="d-inline-block pe-3 lh-lg flex-grow-1" style="color: #fff; font-weight: bold;">Season Winners</div>
-			<div class="d-inline-block">
+	<!-- winner container -->
+	<!-- this data comes from Intra directly, not from Codam's coalition system -->
+	{% if season.coalition_id %}
+		<div class="card w-100 mb-4" id="winner" style="overflow: hidden;">
+			<div class="card-header pe-2 d-flex align-items-center" style="border-bottom: none; background: radial-gradient(ellipse farthest-corner at right bottom, #FEDB37 0%, #FDB931 8%, #9f7928 30%, #8A6E2F 40%, transparent 80%), radial-gradient(ellipse farthest-corner at left top, #FFFFFF 0%, #FFFFAC 8%, #D1B464 25%, #5d4a1f 62.5%, #5d4a1f 100%);">
+				<div class="d-inline-block pe-3 lh-lg flex-grow-1" style="color: #000; font-weight: bold;">Season Winner</div>
+				<div class="d-inline-block">
 
+				</div>
+			</div>
+			<div class="">
+				<ol class="list-group noborder">
+					<li class="list-group-item big-coalition-row" style="background-color: {{ season.coalition.color | rgba(0.5) }}; background-image: url({{ season.coalition.cover_url }})">
+						<a href="/coalitions/{{ season.coalition.id }}">
+							<div class="big-coalition-logo">
+								<img src="{{ season.coalition.image_url }}" style="filter: invert(1);" />
+							</div>
+							<div class="big-coalition-content">
+								<h2 class="coalition-name"><b style="text-transform: uppercase;">{{ season.coalition.name | striptags(true) | escape }}</b></h2>
+							</div>
+						</a>
+					</li>
+				</ol>
 			</div>
 		</div>
-		<div class="">
-			<ol class="list-group list-group-numbered custom-numbers noborder">
-				{% for seasonResult in seasonResults %}
-					<li class="list-group-item big-coalition-row" style="background-color: {{ seasonResult.coalition.intra_coalition.color | rgba(0.5) }}; background-image: url({{ seasonResult.coalition.intra_coalition.cover_url }})">
+	{% endif %}
+
+	<!-- leaderboard result -->
+	{% if seasonResults | length == 0 %}
+		<p class="text-muted p-4"><i>No individual coalition results available for this season.</i></p>
+	{% endif %}
+
+	<!-- leaderboards per coalition -->
+	<!-- this data comes from Codam's coalition system, not from Intra directly -->
+	{% for seasonResult in seasonResults %}
+		<div class="card w-100 mb-4" id="leaderboards" style="overflow: hidden;">
+			<div class="card-header pe-2 d-flex align-items-center" style="background-color: {{ seasonResult.coalition.intra_coalition.color | rgba(0.5) }};">
+				<div class="d-inline-block pe-3 lh-lg flex-grow-1" style="color: #fff; font-weight: bold;">{{ seasonResult.coalition.intra_coalition.name | striptags(true) | escape }} Leaderboards</div>
+				<div class="d-inline-block">
+
+				</div>
+			</div>
+			<div class="">
+				<ol class="list-group list-group-numbered custom-number noborder">
+					<li data-number="{{ loop.index }}" class="list-group-item big-coalition-row" style="background-color: {{ seasonResult.coalition.intra_coalition.color | rgba(0.5) }}; background-image: url({{ seasonResult.coalition.intra_coalition.cover_url }})">
 						<a href="/coalitions/{{ seasonResult.coalition.intra_coalition.id }}">
 							<div class="big-coalition-logo">
 								<img src="{{ seasonResult.coalition.intra_coalition.image_url }}" style="filter: invert(1);" />
@@ -39,12 +72,35 @@
 							</div>
 						</a>
 					</li>
-				{% endfor %}
-			</ol>
+				</ol>
+				<table class="table table-striped mb-0">
+					<tbody>
+						{% for userScore in seasonResult.scores %}
+							<tr style="vertical-align: middle;">
+								<td class="fs-5 p-2" style="width: 25px;">{{ userScore.coalition_rank }}.</td>
+								<td class="p-0">
+									<div class="d-inline-flex flex-row justify-content-start align-items-center text-light">
+										<a href="/profile/{{ userScore.user.intra_user.login }}" class="p-2 text-light" style="text-decoration: none;">
+											<img loading="lazy" src="{{ userScore.user.intra_user.image }}" class="user-picture rounded-circle d-inline-block me-2" height="32" />
+											<span>{{ userScore.user.intra_user.usual_full_name | striptags(true) | escape }}</span>
+										</a>
+									</div>
+								</td>
+								<td class="text-end ps-2 pe-2 mt-0 mb-2">{{ userScore.score | thousands }}</td>
+							</tr>
+						{% endfor %}
+					</tbody>
+				</table>
+				{# if no rankings, display a message #}
+				{% if seasonResult.scores | length == 0 %}
+					<p class="text-muted p-4"><i>No individual leaderboards available for this coalition.</i></p>
+				{% endif %}
+			</div>
 		</div>
-	</div>
+	{% endfor %}
 
 	<!-- rankings -->
+	<!-- this data comes from Codam's coalition system, not from Intra directly -->
 	{% for ranking in rankings %}
 		<div class="card w-100 mb-4" id="ranking-{{ ranking.type }}">
 			<div class="card-header pe-2 d-flex align-items-center" style="background-color: #6c757d;">

--- a/templates/results.njk
+++ b/templates/results.njk
@@ -1,0 +1,85 @@
+{% extends "base.njk" %}
+{% set nomargin = false %}
+{% set title = "Season results" %}
+
+{% block content %}
+
+<!-- Season chooser (basically just a bootstrap.js page navigation) -->
+<nav aria-label="Season navigation" class="d-flex justify-content-center" id="pagenav">
+	<ul class="pagination">
+		{% for endedSeason in endedSeasons %}
+		<li class="page-item">
+			<a class="page-link{{ ' active' if endedSeason.id === season.id }}" href="/results/{{ endedSeason.id }}">{{ endedSeason | seasonName }}</a>
+		</li>
+		{% endfor %}
+	</ul>
+</nav>
+
+<!-- main page content -->
+<div class="container-lg mw-900">
+	<!-- leaderboard result -->
+	<div class="card w-100 mb-4" id="leaderboards" style="overflow: hidden;">
+		<div class="card-header pe-2 d-flex align-items-center" style="background-color: #6c757d;">
+			<div class="d-inline-block pe-3 lh-lg flex-grow-1" style="color: #fff; font-weight: bold;">Season Winners</div>
+			<div class="d-inline-block">
+
+			</div>
+		</div>
+		<div class="">
+			<ol class="list-group list-group-numbered custom-numbers noborder">
+				{% for seasonResult in seasonResults %}
+					<li class="list-group-item big-coalition-row" style="background-color: {{ seasonResult.coalition.intra_coalition.color | rgba(0.5) }}; background-image: url({{ seasonResult.coalition.intra_coalition.cover_url }})">
+						<a href="/coalitions/{{ seasonResult.coalition.intra_coalition.id }}">
+							<div class="big-coalition-logo">
+								<img src="{{ seasonResult.coalition.intra_coalition.image_url }}" style="filter: invert(1);" />
+							</div>
+							<div class="big-coalition-content">
+								<h5 class="coalition-name"><b>{{ seasonResult.coalition.intra_coalition.name | striptags(true) | escape }}</b></h5>
+								<p class="coalition-description">{{ seasonResult.score | thousands }} points</p>
+							</div>
+						</a>
+					</li>
+				{% endfor %}
+			</ol>
+		</div>
+	</div>
+
+	<!-- rankings -->
+	{% for ranking in rankings %}
+		<div class="card w-100 mb-4" id="ranking-{{ ranking.type }}">
+			<div class="card-header pe-2 d-flex align-items-center" style="background-color: #6c757d;">
+				<div class="d-inline-block pe-3 lh-lg flex-grow-1" style="color: #fff; font-weight: bold;">{{ ranking.name | striptags(true) | escape }}</div>
+				<div class="d-inline-block">
+
+				</div>
+			</div>
+			<div class="card-body p-0">
+				<p class="p-4 pb-2">{{ ranking.description | striptags(true) | escape | nl2br }}</p>
+				<table class="table coalition-colored mb-0">
+					<tbody>
+						{% for result in ranking.results %}
+							<tr style="background: {{ result.coalition.intra_coalition.color | rgba(0.25) if result.coalition else 'transparent' }}; vertical-align: middle;">
+								<td class="fs-5 p-2" style="width: 25px;">{{ result.rank }}.</td>
+								<td class="p-0">
+									<div class="d-inline-flex flex-row justify-content-start align-items-center text-light">
+										<a href="/profile/{{ result.user.intra_user.login | striptags(true) | escape }}" class="p-2 text-light" style="text-decoration: none;">
+											<img loading="lazy" src="{{ result.user.intra_user.image }}" class="user-picture rounded-circle d-inline-block me-2" height="32" />
+											<span>{{ result.user.intra_user.usual_full_name | striptags(true) | escape }}</span>
+										</a>
+									</div>
+								</td>
+								<td class="text-end ps-2 pe-2 mt-0 mb-2">{{ result.score | thousands }}</td>
+							</tr>
+						{% endfor %}
+					</tbody>
+				</table>
+				{# if no rankings, display a message #}
+				{% if ranking.results | length == 0 %}
+					<p class="text-muted p-4"><i>No rankings available for this season.</i></p>
+				{% endif %}
+			</div>
+		</div>
+	{% endfor %}
+</div>
+
+{% endblock %}

--- a/templates/results.njk
+++ b/templates/results.njk
@@ -113,6 +113,7 @@
 				<p class="p-4 pb-2">{{ ranking.description | striptags(true) | escape | nl2br }}</p>
 				<table class="table coalition-colored mb-0">
 					<tbody>
+						{# TODO: build a nice big highlight of the winner(s) #}
 						{% for result in ranking.results %}
 							<tr style="background: {{ result.coalition.intra_coalition.color | rgba(0.25) if result.coalition else 'transparent' }}; vertical-align: middle;">
 								<td class="fs-5 p-2" style="width: 25px;">{{ result.rank }}.</td>


### PR DESCRIPTION
This pull request adds the finishing touches to the seasons in the coalition system and reworks a couple of small things.

- Added database tables where season results can be stored for later use.
- Rankings are now based on seasons as well. Scrapped the idea of tournaments consisting of x amount of seasons, or at least in the code.
- Added database tables where ranking results can be stored for later use.
- Added a "Results" page where past season results can be viewed.
- Added a custom webhook that is supposed to handle automated logouts from idling computers, punishing students for doing so.
- Removed some unused lines from some graphs.
- Add basic search functionality to view other user profiles without having to modify the page url.