### PR TITLE
fix: never deduct coalition points on a project/exam retry

### DIFF
--- a/src/handlers/points.ts
+++ b/src/handlers/points.ts
@@ -155,11 +155,21 @@ export const handleFixedPointScore = async function(prisma: PrismaClient, type: 
 
 		if (existingScores._sum.amount !== null) {
 			// Score(s) were already given for this type and typeIntraId in the past.
-			// Calculate the point difference and hand out the difference as a new score.
-			const pointDifference = Math.floor(Math.floor(points) - existingScores._sum.amount);
-			if (pointDifference > -10 && pointDifference < 1) {
-				console.log(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Point difference is (close to) 0, no need to create a new score.`);
-				return null; // No difference in points, no need to create a new score
+			// Calculate the point difference and hand out the difference as a new score
+			// when the user has earned more points than before. Retries must never
+			// deduct points: a negative difference means the formula or its config
+			// (point_amount, project.difficulty, ...) has changed since the original
+			// score was written, and we should not punish a user for re-evaluating
+			// something they had already passed.
+			const pointDifference = Math.floor(points) - existingScores._sum.amount;
+			if (pointDifference < 1) {
+				if (pointDifference < -10) {
+					console.warn(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Recomputed points (${Math.floor(points)}) are ${-pointDifference} below the existing total (${existingScores._sum.amount}); suppressing to avoid taking points away on a retry. This usually indicates the scoring config has changed since the original score was awarded.`);
+				}
+				else {
+					console.log(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Point difference is ${pointDifference} (<= 0), no need to create a new score.`);
+				}
+				return null;
 			}
 			console.log(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Point difference is ${pointDifference}, handing out the difference as a new score...`);
 			return await createScore(prisma, type, typeIntraId, userId, pointDifference, reason, scoreDate);


### PR DESCRIPTION
## Problem

Re-evaluating a project a user had already passed can take coalition points away from them.

Real example from a student on our campus:

| When         | Mark | Points awarded | Reason                                     |
| ------------ | ---: | -------------: | ------------------------------------------ |
| 131 days ago |  98% |           +866 | Validated `42_Collaborative_resume` …      |
|  20 days ago | 100% |            −86 | Validated `42_Collaborative_resume` (retry) |

The student validated the same project again at a *higher* mark and lost 86 points. Same pattern is visible on several other projects on that account (Cybersecurity – Vaccine - Web 102 % → −140, arachnida - Web 120 % → −166).

## Root cause

[`handleFixedPointScore`](https://github.com/codam-coding-college/coalition-system/blob/master/src/handlers/points.ts) is meant to be a **top-up** mechanism on retries: it sums all prior score rows for the same `(user_id, fixed_type_id, type_intra_id)` triple and awards `pointDifference = newPoints − sumOfPrior` so the user's total over all rows ends up at `newPoints`.

That works fine as long as the formula and its inputs (`fixedPointType.point_amount`, `project.difficulty`) are stable. But:

- `point_amount` is editable by admins from the admin panel (`src/routes/admin/points.ts`)
- `project.difficulty` is synced from Intra and can change over time

When either drops between the original validation and a retry, the recomputed `newPoints` is **lower** than the historical row, so `pointDifference` becomes a large negative number — and the existing guard only suppresses *tiny* negatives:

```ts
if (pointDifference > -10 && pointDifference < 1) { return null; }
```

So a `−86` slips through and gets written as a real `CodamCoalitionScore` row with the reason “Validated X with N%”. The user loses points for re-evaluating a project they had already passed, which is the opposite of the intent.

No date / season multiplier exists in the project-score path (traced from `projects_users.ts:100` → `handleFixedPointScore` → `createScore` → DB; `syncIntraScore` only mirrors). The only time-sensitive multiplier in the repo is the evaluation-points sale in `scale_teams.ts`, which does not touch project validations.

## Fix

Suppress *any* `pointDifference <= 0` instead of just the small-negative band. The original intent ("hand out the difference when a retry earned more") is preserved exactly for positive diffs. A `console.warn` is emitted when a large negative is suppressed, so admins can spot scoring-config drift in the logs without it silently affecting students.

```ts
const pointDifference = Math.floor(points) - existingScores._sum.amount;
if (pointDifference < 1) {
  if (pointDifference < -10) console.warn(/* drift warning with details */);
  else                       console.log(/* small noise, as before */);
  return null;
}
```

No DB migration or backfill is included — only the runtime decision changes from this point on. Existing negative score rows that have already been written are untouched and would need a separate admin-driven cleanup if desired.

## Notes / things to confirm

- The fix is intentionally minimal and applies symmetrically to all `handleFixedPointScore` callers (projects, exams, pools), since the "never take points away on a retry" property is desirable across the board. If exams should behave differently, happy to scope it down.
- The `Math.floor(Math.floor(...))` double-floor on the old line was removed (it was a no-op).
- If you want, I can follow up with a small admin script that lists all `CodamCoalitionScore` rows with `amount < 0` whose `fixed_type_id` is `project` or `exam`, so the existing damage can be reviewed and optionally reverted.

## How I verified

- Traced the full point-write pipeline (`projects_users.ts` → `points.ts` → `intrascores.ts`) to confirm no date multiplier exists for project scores.
- Searched `prisma/` for schema fields and recent migrations to make sure no implicit transformation happens on insert.
- Reviewed `git log` on the affected files since 2026-01-01; the only formula change in that window was `a597e87` (exam-mark scaling), which does not affect the example project above.
- TypeScript compile clean (`get_errors` reports no diagnostics on the edited file).
