### PR TITLE
chore(dev): script to list (and optionally revert) negative project/exam retry scores

### DIFF
--- a/src/dev/list_negative_retry_scores.ts
+++ b/src/dev/list_negative_retry_scores.ts
@@ -1,0 +1,90 @@
+import { prisma } from '../handlers/db';
+import readline from 'readline';
+
+// Lists all CodamCoalitionScore rows that deducted points from a user as a
+// result of a project or exam retry (amount < 0, fixed_type_id in {project, exam}).
+//
+// Before the fix in handlers/points.ts (PR #24), handleFixedPointScore would
+// happily write a negative score row whenever a retry's new total ended up
+// lower than the sum of previously awarded points (e.g. because an admin
+// lowered point_amount, or Intra updated project.difficulty between attempts).
+//
+// Run with `--revert` to delete the listed rows after a confirmation prompt.
+// Without the flag this is read-only.
+
+const TYPES = ['project', 'exam'];
+
+const main = async function(): Promise<void> {
+	const revert = process.argv.includes('--revert');
+
+	const rows = await prisma.codamCoalitionScore.findMany({
+		where: {
+			amount: { lt: 0 },
+			fixed_type_id: { in: TYPES },
+		},
+		include: {
+			user: { select: { intra_user: { select: { login: true } } } },
+			coalition: { select: { intra_coalition: { select: { name: true } } } },
+		},
+		orderBy: [{ user_id: 'asc' }, { created_at: 'asc' }],
+	});
+
+	if (rows.length === 0) {
+		console.log('No negative project/exam scores found. Nothing to do.');
+		return;
+	}
+
+	console.log(`Found ${rows.length} negative project/exam score row(s):\n`);
+	console.log('id\tuser\tcoalition\ttype\tamount\ttype_intra_id\treason');
+	console.log('-'.repeat(80));
+
+	const totalsByUser = new Map<string, number>();
+	let grandTotal = 0;
+	for (const row of rows) {
+		const login = row.user.intra_user?.login ?? `user#${row.user_id}`;
+		console.log([
+			row.id,
+			login,
+			row.coalition.intra_coalition.name,
+			row.fixed_type_id,
+			row.amount,
+			row.type_intra_id ?? '',
+			row.reason,
+		].join('\t'));
+		totalsByUser.set(login, (totalsByUser.get(login) ?? 0) + row.amount);
+		grandTotal += row.amount;
+	}
+
+	console.log('\nTotal deducted per user:');
+	for (const [login, total] of [...totalsByUser.entries()].sort((a, b) => a[1] - b[1])) {
+		console.log(`  ${login}\t${total}`);
+	}
+	console.log(`\nGrand total: ${grandTotal} points across ${totalsByUser.size} user(s).`);
+
+	if (!revert) {
+		console.log('\nRead-only run. Re-run with `--revert` to delete these rows.');
+		return;
+	}
+
+	console.log(`\nAbout to DELETE the ${rows.length} row(s) listed above. Type "yes" to confirm.`);
+	const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+	const answer: string = await new Promise((resolve) => {
+		rl.question('', (a) => { rl.close(); resolve(a); });
+	});
+	if (answer !== 'yes') {
+		console.log('Aborting, nothing was deleted.');
+		return;
+	}
+
+	const result = await prisma.codamCoalitionScore.deleteMany({
+		where: { id: { in: rows.map((r) => r.id) } },
+	});
+	console.log(`Deleted ${result.count} row(s).`);
+};
+
+main().then(() => {
+	process.exit(0);
+}).catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
Companion to #24.

After that PR stops the bleeding, admins still need to know which `CodamCoalitionScore` rows the old `handleFixedPointScore` already wrote with negative amounts on project/exam retries. This adds a small read-only dev script for that, with an opt-in `--revert` flag for cleanup.

## What it does

```sh
npx ts-node src/dev/list_negative_retry_scores.ts
```

- Selects every `CodamCoalitionScore` where `amount < 0` AND `fixed_type_id IN ('project', 'exam')`.
- Joins through `CodamUser → IntraUser` for the login and `CodamCoalition → IntraCoalition` for the coalition name.
- Prints one tab-separated line per row (`id`, `login`, `coalition`, `type`, `amount`, `type_intra_id`, `reason`), then a per-user total and a grand total.
- With no flag, it is read-only.

```sh
npx ts-node src/dev/list_negative_retry_scores.ts --revert
```

- Same listing, then asks for a `yes` confirmation and `deleteMany` on the listed `id`s.

Follows the same style as the other one-off scripts in `src/dev/` (e.g. `delete_all_scores.ts`).

## Why not just fold it into the fix PR

Keeps #24 minimal and reviewable (it touches the hot path). This branch only adds a new file under `src/dev/`, no runtime code is affected.

## Notes

- Does NOT touch ranking results, season results, or anything derived. If you intend to revert and the season has already been frozen via `CodamCoalitionSeasonResult`, you'll want to recompute those separately.
- I'd suggest running it once read-only first, eyeballing the output, then deciding whether to `--revert` or hand-pick individual ids.
