### PR TITLE
feat: always record a row on project/exam retry, label as Retried

### DIFF
--- a/src/handlers/points.ts
+++ b/src/handlers/points.ts
@@ -164,25 +164,30 @@ export const handleFixedPointScore = async function(prisma: PrismaClient, type: 
 		});
 
 		if (existingScores._sum.amount !== null) {
-			// Score(s) were already given for this type and typeIntraId in the past.
-			// Calculate the point difference and hand out the difference as a new score
-			// when the user has earned more points than before. Retries must never
-			// deduct points: a negative difference means the formula or its config
-			// (point_amount, project.difficulty, ...) has changed since the original
-			// score was written, and we should not punish a user for re-evaluating
-			// something they had already passed.
+			// Score(s) were already given for this type and typeIntraId in the past,
+			// so this call is a retry. Compute the point difference against the
+			// historical total and:
+			//   - hand out the difference when the user earned more points than before;
+			//   - record a 0-point row when the user did equally well or worse, so
+			//     the retry stays visible on the user's profile without ever
+			//     deducting points (a negative diff usually means the scoring
+			//     config -- point_amount, project.difficulty, ... -- changed since
+			//     the original row was written, and we should not punish a user for
+			//     re-evaluating something they had already passed).
 			const pointDifference = Math.floor(points) - existingScores._sum.amount;
-			if (pointDifference < 1) {
-				if (pointDifference < -10) {
-					console.warn(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Recomputed points (${Math.floor(points)}) are ${-pointDifference} below the existing total (${existingScores._sum.amount}); suppressing to avoid taking points away on a retry. This usually indicates the scoring config has changed since the original score was awarded.`);
-				}
-				else {
-					console.log(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Point difference is ${pointDifference} (<= 0), no need to create a new score.`);
-				}
-				return null;
+			if (pointDifference < -10) {
+				console.warn(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Recomputed points (${Math.floor(points)}) are ${-pointDifference} below the existing total (${existingScores._sum.amount}); clamping to 0 to avoid taking points away on a retry. This usually indicates the scoring config has changed since the original score was awarded.`);
 			}
-			console.log(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Point difference is ${pointDifference}, handing out the difference as a new score...`);
-			return await createScore(prisma, type, typeIntraId, userId, pointDifference, reason, scoreDate);
+			const awardedPoints = pointDifference > 0 ? pointDifference : 0;
+			// Relabel the reason so the score history makes it clear this row
+			// represents a retry, not a first-time validation.
+			const retryReason = reason.startsWith('Validated ')
+				? `Retried ${reason.slice('Validated '.length)}`
+				: `Retried: ${reason}`;
+			console.log(`Score(s) already exist for type ${type.type} and typeIntraId ${typeIntraId}. Point difference is ${pointDifference}, recording retry as ${awardedPoints} point(s)...`);
+			// Skip the Intra sync for 0-point audit rows: they don't change the
+			// coalition total and would just add noise on Intra.
+			return await createScore(prisma, type, typeIntraId, userId, awardedPoints, retryReason, scoreDate, awardedPoints !== 0);
 		}
 	}
 


### PR DESCRIPTION
## Problem

Two related symptoms on the score history of a user's profile:

1. **Retries on equal marks are invisible.** When a student re-evaluates a project and lands on the same `final_mark` as before (very common — 100 → 100, 125 → 125 on bonus projects), `handleFixedPointScore` computes `pointDifference == 0` and returns without writing any row. The profile shows no trace that the retry happened.
2. **Retries after a downward scoring-config change are invisible too.** Since #24, any retry whose recomputed total is below the historical total is suppressed (correctly, to never deduct points). But the user also sees nothing on their profile, even though their re-evaluation did happen. Real example from our campus: a `Cybersecurity - arachnida - Web` retry at 120% after an admin lowered the fixed project `point_amount` — the row that would have appeared as `-166` pre-#24 now simply doesn't appear at all.

Separately, the rows that *do* get written on a retry use the upstream reason `Validated <name> with N%`, which reads exactly like a first-time validation and (pre-#24) was actively misleading on negative-amount rows.

## Fix

On the retry branch in `handleFixedPointScore`, always create a row, but never let a retry deduct points:

```ts
const pointDifference = Math.floor(points) - existingScores._sum.amount;
if (pointDifference < -10) {
    console.warn(/* drift warning */);
}
const awardedPoints = pointDifference > 0 ? pointDifference : 0;
const retryReason = reason.startsWith('Validated ')
    ? `Retried ${reason.slice('Validated '.length)}`
    : `Retried: ${reason}`;
return await createScore(prisma, type, typeIntraId, userId, awardedPoints, retryReason, scoreDate, awardedPoints !== 0);
```

Behaviour matrix on the retry path:

| `pointDifference` | row written | `amount` | Intra sync | reason                       |
|-------------------|-------------|----------|------------|------------------------------|
| `> 0`             | yes         | `diff`   | yes        | `Retried <name> with N%`     |
| `== 0`            | yes         | `0`      | no         | `Retried <name> with N%`     |
| `< 0`             | yes         | `0`      | no         | `Retried <name> with N%`     |
| `< -10`           | same as above + `console.warn` for drift detection                       |

First-time validations are untouched.

## Properties preserved

- **#24's invariant holds.** Negative diffs are clamped to 0, not written through. The coalition total never drops on a retry.
- **No Intra noise.** 0-point audit rows skip `syncIntraScore` via the existing `syncWithIntra` arg on `createScore`, so they don't generate score entries on Intra.
- **Drift detection unchanged.** The `console.warn` for `pointDifference < -10` still fires, so admins can spot scoring-config drift in logs.
- **No schema / migration change.** Templates (`profile.njk`, `history.njk`) render `{{ score.amount | thousands }}` for every row, which renders 0 as `0` — no template tweak needed.
- **PR #25's cleanup script is unaffected.** Existing pre-#24 negative `Validated …` rows in the DB still need that script if you want to clean them up.

## Notes / things to confirm

- The relabel is a plain `startsWith('Validated ')` swap. The upstream string is built in [`src/routes/hooks/projects_users.ts`](src/routes/hooks/projects_users.ts) as ``Validated ${project.name} with ${projectUser.final_mark}%`` for both projects and exams, so this catches the common case. The `Retried: <reason>` fallback keeps the label informative if a future caller passes a different `reason`.
- Aggregations on `amount` are unaffected (adding 0 is a no-op). If anywhere counts *rows* per user, the retry rows will now inflate that count slightly — I didn't find such a place in a quick scan of `src/`, but worth a second pair of eyes.
- The fix applies symmetrically to all `handleFixedPointScore` callers (projects, exams, pools), in line with #24's scope.

## How I verified

- TypeScript compile clean on the edited file.
- Walked the call chain `projects_users.ts → handleFixedPointScore → createScore → syncIntraScore` to confirm the `syncWithIntra=false` path skips the Intra write for 0-amount rows.
- Read both score-history templates (`templates/profile.njk`, `templates/history.njk`) to confirm `{{ amount | thousands }}` renders 0 as `0`, not blank.
- Re-checked the example from #24: a `Cybersecurity - arachnida - Web 120%` retry that previously wrote `-166` would, under this PR, write a `0`-point `Retried Cybersecurity - arachnida - Web with 120%` row plus a `console.warn`, instead of writing nothing.
