### PR TITLE
feat(intra): label re-evaluated project/exam scores as Retried

### DIFF
--- a/src/routes/hooks/projects_users.ts
+++ b/src/routes/hooks/projects_users.ts
@@ -107,8 +107,12 @@ export const handleProjectsUserUpdateWebhook = async function(prisma: PrismaClie
 			return (res ? respondWebHookHandledStatus(prisma, webhookDeliveryId, res, WebhookHandledStatus.Skipped) : null);
 		}
 		const updatedAt = new Date(projectUser.updated_at); // Could use markedAt, but the updated_at is more reliable (marked_at can be months ago if the evaluation feedback was filled in months after the project was marked)
+		// occurrence == 0 is the first attempt; any value above that means the user re-evaluated the
+		// project (or exam), so label the score row accordingly to disambiguate retries from first-time
+		// validations on the user's score history.
+		const verb = (projectUser.occurrence && projectUser.occurrence > 0) ? 'Retried' : 'Validated';
 		const score = await handleFixedPointScore(prisma, fixedPointType, projectUser.id, userId, points,
-			`Validated ${project.name} with ${projectUser.final_mark}%`, updatedAt);
+			`${verb} ${project.name} with ${projectUser.final_mark}%`, updatedAt);
 		if (!score) {
 			console.warn("Refused or failed to create score, skipping...");
 			return (res ? respondWebHookHandledStatus(prisma, webhookDeliveryId, res, WebhookHandledStatus.Skipped) : null);


### PR DESCRIPTION
## Context

Follow-up to #26 (closed), addressing @FreekBes's review:

> The coalition system is not a general activity log for the 42 cursus. Only events that directly affect the coalition system should be logged. […]
> Regarding the "Validated" → "Retried" change: the function you modified is shared across all score types, not just projects, so adding project-specific retry logic there isn't appropriate. Its sole responsibility is creating scores, not adjusting their labels.
> […] If you wish to make a change like this, make it in the `handleProjectsUserUpdateWebhook` function. The `occurrence` field in the `projectUser` object will indicate whether or not the project was retried and with that the reason could be adjusted there (on line 110).

This PR does exactly — and only — that.

## Change

`src/routes/hooks/projects_users.ts`, in `handleProjectsUserUpdateWebhook`, at the line that builds the score reason:

```ts
const verb = (projectUser.occurrence && projectUser.occurrence > 0) ? 'Retried' : 'Validated';
const score = await handleFixedPointScore(prisma, fixedPointType, projectUser.id, userId, points,
    `${verb} ${project.name} with ${projectUser.final_mark}%`, updatedAt);
```

| `projectUser.occurrence` | reason written |
|---|---|
| `0` (first attempt) | `Validated <name> with N%` (unchanged) |
| `> 0` (retry) | `Retried <name> with N%` |
| `null` / missing (defensive) | falls back to `Validated …` |

## What this PR does NOT do

- **No changes to `handleFixedPointScore`.** The shared scoring helper keeps its sole responsibility (creating scores). The pre-#24 + #24 behaviour is preserved: zero/negative-diff retries still produce no row at all, so we don't pollute the score history with coalition-irrelevant events.
- **No schema, no migration, no template changes.**
- **No effect on first-time validations.**

## Scope

The webhook handles both projects and exams in the same code path (the `if (project.exam)` branch above). Intra populates `occurrence` for both, so an exam redo will read `Retried <exam-name> with N%` — consistent with project retries. Pool scoring goes through a different webhook and is untouched.

## Verification

- `tsc` clean on the edited file.
- Logic table walked manually for `occurrence ∈ {0, 1, 2, null, undefined}`; verb selection matches the table above.
- Diff is 1 file, +5 / −1.
